### PR TITLE
Send verified ads using a webhook

### DIFF
--- a/cogs/advertisements.py
+++ b/cogs/advertisements.py
@@ -183,16 +183,13 @@ class Advertisements(commands.Cog):
 
         guild = self.client.get_guild(self.client.config["guild_id"])
         member = guild.get_member(ad_to_post["user_id"])
+        wh = discord.Webhook.from_url(self.client.config["verified_promotions_webhook"], session=self.client.session)
 
-        author = f"Sent by: {ad_to_post['user_id']}"
+        author, avatar = f"Submitted by: {ad_to_post['user_id']}", self.client.user.display_avatar.url
         if member is not None and len(str(member)) <= 70:
-            author = f"Sent by: {member}"
+            author, avatar = member.display_name, member.display_avatar.url
 
-        verified_promotions_channel = self.client.get_channel(self.client.config["channel_id"]["verified_promotions"])
-
-        button_view = discord.ui.View()
-        button_view.add_item(item=discord.ui.Button(label=author, disabled=True))
-        await verified_promotions_channel.send(ad_to_post["content"], view=button_view)
+        await wh.send(ad_to_post["content"], username=author, avatar_url=avatar)
 
     @post_advertisement.before_loop
     async def post_advertisement_before_loop(self) -> None:

--- a/discord_bot_owners.py
+++ b/discord_bot_owners.py
@@ -4,6 +4,7 @@ import json
 import os
 from typing import Optional, TYPE_CHECKING
 
+import aiohttp
 import discord
 from discord.ext import commands
 
@@ -55,6 +56,8 @@ class DiscordBotOwners(commands.Bot):
     """ Setup actions. """
 
     async def setup_hook(self) -> None:
+        self.session = aiohttp.ClientSession()
+
         self.loop.create_task(self.ready_actions())
 
         for filename in os.listdir("./cogs"):
@@ -69,6 +72,10 @@ class DiscordBotOwners(commands.Bot):
         guild = discord.Object(id=self.config["guild_id"])
         self.tree.copy_global_to(guild=guild)
         await self.tree.sync(guild=guild)
+
+    async def close(self) -> None:
+        await self.session.close()
+        await super().close()
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.pyright]
+typeCheckingMode = "off"
+
+stubPath = "."


### PR DESCRIPTION
Okay, so in order for this to work, a webhook needs to be created in the verified promos channel, then just set the key `verified_promotions_webhook` to the webhook's url in the `config.json` file