### PR TITLE
Verification supports up to 4 images & suggestion avatars to not expire

### DIFF
--- a/cogs/general.py
+++ b/cogs/general.py
@@ -102,7 +102,7 @@ class SuggestModal(discord.ui.Modal, title="Suggestion"):
         )
 
         suggestion_embed.set_footer(
-            text=f"{interaction.user}", icon_url=interaction.user.avatar.url
+            text=f"{interaction.user}", icon_url=f"https://ava.viadev.xyz/{interaction.user.id}"
         )
 
         suggestion_channel = interaction.guild.get_channel(


### PR DESCRIPTION
Bot owner verification required that you upload an image as proof but some people upload more than 1 image then get denied when the bot only passes on their first image. I have added support up to 4 images to verification.
![image](https://github.com/user-attachments/assets/64d09027-1c49-43e1-a515-1b548a40391c)

I have also changed the avatar url for suggestion embeds on the bot to use https://ava.viadev.xyz . This is a "proxy" I made that allows you to just use an url with someone's id in it to get their avatar like https://ava.viadev.xyz/402888568579686401 , this will always redirect to their current avatar and the link will never become invalid hence the avatar will never disappear on the embed when someone changes their avatar.
